### PR TITLE
Disable Search component in footer temporary

### DIFF
--- a/src/components/custom-footer.tsx
+++ b/src/components/custom-footer.tsx
@@ -14,7 +14,8 @@ const CustomFooter = async () => {
             <ThemeSwitch />
             <div>© {new Date().getFullYear()} rinae</div>
           </div>
-          <Search placeholder="글 검색..." />
+          {/*FIXME: Pagefind is not working on production env*/}
+          {/*<Search placeholder="글 검색..." />*/}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Pagefind fails in production; comment out Search usage and add a FIXME for follow-up