### PR TITLE
style: format MDX posts with Prettier

### DIFF
--- a/content/posts/a-complete-guide-to-useeffect-ko.mdx
+++ b/content/posts/a-complete-guide-to-useeffect-ko.mdx
@@ -802,7 +802,7 @@ function SearchResults() {
 
 _([Hooks FAQ](https://reactjs.org/docs/hooks-faq.html#is-it-safe-to-omit-functions-from-the-list-of-dependencies)에서 그 대신 어떻게 해야하는지 설명합니다. 위의 예제는 [아랫부분](https://overreacted.io/a-complete-guide-to-useeffect/#moving-functions-inside-effects)에서 다시 다루겠습니다.)_
 
-"하지만 저는 마운트 될 때만 이펙트를 실행하고 싶다고요!" 라고 하실 수 있습니다. 일단 지금은 deps를 지정한다면, **컴포넌트에 있는 _모든_ 값 중 그 이펙트에 사용될 값은 _반드시_ 거기 있어야 한다**는 것을 기억해 두세요. props, state, 함수들 등 컴포넌트 안에 있는 모든 것 말입니다.
+"하지만 저는 마운트 될 때만 이펙트를 실행하고 싶다고요!" 라고 하실 수 있습니다. 일단 지금은 deps를 지정한다면, **컴포넌트에 있는 *모든* 값 중 그 이펙트에 사용될 값은 *반드시* 거기 있어야 한다**는 것을 기억해 두세요. props, state, 함수들 등 컴포넌트 안에 있는 모든 것 말입니다.
 
 가끔은 위의 코드처럼 하면 문제를 일으킵니다. 예를 들어 데이터 불러오는 로직이 무한 루프에 빠질 수도 있고, 소켓이 너무 자주 반응할 수도 있습니다. **이런 문제를 해결하는 방법은 의존성을 제거하는 것이 _아닙니다._** 곧 그 해결책을 살펴보겠습니다.
 

--- a/content/posts/understanding-taming-the-meta-language-kor.mdx
+++ b/content/posts/understanding-taming-the-meta-language-kor.mdx
@@ -132,9 +132,7 @@ state = {
 
 ```typescript
 type State =
-  | { progress: 'loading' }
-  | { progress: 'done'; data: Object }
-  | { progress: 'error'; error: Error }
+  { progress: 'loading' } | { progress: 'done'; data: Object } | { progress: 'error'; error: Error }
 ```
 
 **리덕스(Redux)와 불변성(Immutability):** 현재는 문서, 블로그 포스트, 비디오, 컨퍼런스 발표 등에서 리덕스를 사용할 때 변수나 객체에 직접적으로 변화를 주지 않을 것을(lack of direct mutation) 전제하고 있습니다. 만약 자바스크립트가 기본적으로 불변 데이터 타입과 타입 선언(type annotations)을 제공한다면 위에서 말하는 전제를 코드에서 바로 표현할 수 있지 않을까요?


### PR DESCRIPTION
## Summary
- format the two MDX posts previously reported by `pnpm format:check`
- preserve content and limit the diff to Prettier output

## Verification
- `pnpm format:check` ✅
- `pnpm build` ✅ 126 static pages generated
- pre-commit hook ✅
- pre-push build hook ✅